### PR TITLE
Browsers do not need all files

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter;
-var all = require('q').all;
 var Promise = require('q').Promise;
 var semver = require('semver');
 var throat = require('throat')(Promise);
@@ -61,7 +60,7 @@ function updateLocalHash(file) {
 function getAppHost(config) {
   function cordovaAppHost() {
     return new Promise(function (resolve, reject) {
-      if (config.ignoreAppSettings || typeof window.plugins === 'undefined') {
+      if (!isCordova || config.ignoreAppSettings || typeof window.plugins === 'undefined') {
         return resolve();
       }
       return window.plugins.appPreferences.fetch(resolve, reject, 'appHost');
@@ -72,7 +71,7 @@ function getAppHost(config) {
     return fs.dir().then(function (directoryEntry) { return directoryEntry.nativeURL; });
   }
 
-  return all([ cordovaAppHost(), publicPath() ]).then(function (moreConfig) {
+  return Promise.all([cordovaAppHost(), publicPath()]).then(function (moreConfig) {
     return {
       appHost: moreConfig[0],
       publicPath: moreConfig[1]
@@ -156,7 +155,7 @@ function validateAppManifest(manifest, config) {
 function getAppManifest(config) {
   var path = config.manifestFile;
 
-  return all([ localFile(path), remoteFile(path, config) ]).then(function (files) {
+  return Promise.all([ localFile(path), remoteFile(path, config) ]).then(function (files) {
     var localFile = files[0];
     var remoteFile = files[1];
 
@@ -181,7 +180,6 @@ function getAppManifest(config) {
 
         fileReader.onload = function(event) {
           file.content = JSON.parse(event.target.result);
-
           resolve(file);
         };
 
@@ -202,15 +200,20 @@ function getAppManifest(config) {
 }
 
 function getFilesToLoad(manifest, config) {
-  return new Promise(function (resolve) {
-    var filesToLoad = Object.keys(manifest.files).map(function (key) {
-      return manifest.files[key];
-    }).filter(function (file) {
-      return file && (!config.useLocalCache || file.hash != localHashes[file.path]);
+  var fileNames = Object.keys(manifest.files);
+  if (!isCordova) {
+    // Get only files needed as dom node
+    fileNames = manifest.domNodes.map(function (domNode) {
+      return domNode.path;
     });
-
-    return resolve(filesToLoad);
+  }
+  var filesToLoad = fileNames.map(function (fileName) {
+    return manifest.files[fileName];
+  }).filter(function (file) {
+    return file && (!config.useLocalCache || file.hash != localHashes[file.path]);
   });
+
+  return filesToLoad;
 }
 
 function writeFile(file, config) {
@@ -309,7 +312,7 @@ function downloadFiles(config, files) {
     return downloadFile(config, file);
   }));
 
-  return all(promises);
+  return Promise.all(promises);
 }
 
 function updateNodeAttributes(node, nodeInfo) {
@@ -520,7 +523,7 @@ function loadFilesFromCache(manifest, fileCache, files) {
     }
   });
 
-  return all(filesToLoad.map(function (file) {
+  return Promise.all(filesToLoad.map(function (file) {
     return fs.read(file.path).then(function (content) {
       fileCache[file.path] = { manifestEntry: file, content: content };
     }).catch(function (error) {
@@ -544,7 +547,7 @@ loader.unsupportedBrowserLoad = function (config) {
 
     validateAppManifest(manifest, config);
 
-    all(manifest.domNodes.map(throat(1, function (nodeInfo) {
+    Promise.all(manifest.domNodes.map(throat(1, function (nodeInfo) {
       return createNode(loader.fileCache, nodeInfo, config);
     })));
   });
@@ -561,13 +564,13 @@ loader.normalLoad = function (config) {
   }).then(function (files) {
     return downloadFiles(config, files);
   }).then(function (files) {
-    return all(files.map(function (file) {
+    return Promise.all(files.map(function (file) {
       return writeFile(file, config);
     }));
   }).then(function (files) {
     return loadFilesFromCache(manifest, fileCache, files);
   }).then(function () {
-    return all(manifest.domNodes.map(throat(1, function (nodeInfo) {
+    return Promise.all(manifest.domNodes.map(throat(1, function (nodeInfo) {
       return createNode(fileCache, nodeInfo, config);
     })));
   });


### PR DESCRIPTION
Everything in the `files` section of the manifest is purely for Cordova use.
So if we are not a Cordova app, we skip the download of the files.