### PR TITLE
Removed babel-polyfill in favor of a more specific polyfill for Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # ts-loader CHANGELOG
 
-## v2.8.0
+## NEXT
+- Removed babel-polyfill in favor of a more specific polyfill for Promise
+
+## v2.8.0 - 2017-05-22
 - Changed code to ES6 syntax
 - Use stricter eslint rules
 - Cleaned up some code

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.0.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "classlist-polyfill": "^1.2.0",
+    "core-js": "^2.4.1",
     "element-dataset": "^2.2.6",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
@@ -33,7 +33,7 @@
     "semver": "^5.3.0",
     "spark-md5": "^3.0.0",
     "throat": "^3.0.0",
-    "webpack": "^2.2.0-rc.4",
+    "webpack": "^2.6.1",
     "webpack-dev-middleware": "^1.9.0",
     "webpack-dev-server": "^2.2.0-rc.0"
   }

--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -1,6 +1,6 @@
-var webpack = require('webpack');
+const webpack = require('webpack');
 
-var devConfig = require('./webpack.config.js');
+const devConfig = require('./webpack.config.js');
 
 // Remove the webpack-dev-server from entries
 devConfig.entry['ts-loader'].shift();
@@ -9,7 +9,7 @@ devConfig.entry['ts-loader'].shift();
 devConfig.plugins.unshift(
   new webpack.DefinePlugin({
     'process.env': {
-      'NODE_ENV': JSON.stringify('production')
+      NODE_ENV: JSON.stringify('production')
     }
   })
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,14 @@ const port = 8080;
 module.exports = {
   entry: {
     'ts-loader': [
-      'webpack-dev-server/client?http://' + host + ':' + port,
-      'babel-polyfill',
+      `webpack-dev-server/client?http://${host}:${port}`,
+      'core-js/fn/promise',
       './lib/index.js'
     ],
-    'ts-loader.min': './lib/index.js'
+    'ts-loader.min': [
+      'core-js/fn/promise',
+      './lib/index.js'
+    ]
   },
   output: {
     path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
This is mostly due to babel-polyfill not being able to handle multiple import of itself.