### PR TITLE
[fix] read file as buffer to avoid encoding issue

### DIFF
--- a/lib/cordova-promise-fs.js
+++ b/lib/cordova-promise-fs.js
@@ -339,12 +339,13 @@ module.exports = function(options){
     method = method || 'readAsText';
     return file(path).then(function(fileEntry) {
       return new Promise(function(resolve,reject){
-        fileEntry.file(function(file){
+        fileEntry.file(function(fileObject){
           var reader = new FileReader();
-          reader.onloadend = function(){
-            resolve(this.result);
+          reader.onload = function(evt){
+            resolve(evt.target.result);
           };
-          reader[method](file);
+          reader.onerror = reject;
+          reader[method](fileObject);
         },reject);
       });
     });
@@ -362,8 +363,7 @@ module.exports = function(options){
 
   /* write contents to a file */
   function write(path,blob,mimeType) {
-    return ensure(dirname(path))
-      .then(function() { return file(path,{create:true}); })
+    return create(path)
       .then(function(fileEntry) {
         return new Promise(function(resolve,reject){
           fileEntry.createWriter(function(writer){

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -533,17 +533,18 @@ function loadFilesFromCache(manifest, fileCache, files) {
   });
 
   return Promise.all(filesToLoad.map((file) => {
-    return fs.read(file.path)
-      .then((content) => {
-        fileCache[file.path] = { manifestEntry: file, content };
+    return fs.read(file.path, 'readAsArrayBuffer')
+      .then((fileBuffer) => {
+        fileCache[file.path] = { manifestEntry: file, fileBuffer };
       })
       .catch((error) => {
         console.error(error);
+        throw error;
       });
   }));
 }
 
-loader.FunsupportedBrowserLoad = (config) => {
+loader.unsupportedBrowserLoad = (config) => {
   let manifest;
   const url = `${(config.appHost || '')}/${config.manifestFile}`;
 


### PR DESCRIPTION
Issue seen on ts_ember.

When using `readAsText` we are getting an encoding error.
Using `readAsArrayBuffer` instead and letting the actual code turning the buffer into "text".

(Also making sure we are catching the error)
(Also a typo fix)