### PR TITLE
fix(cordovaLoad): use webview caching for styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.log
+/.gtm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/kkvesper/ts-loader/compare/3.1.1...3.1.2) (2018-09-14)
+
+
+### Bug Fixes
+
+* **cordovaLoad:** use webview caching for styles ([53bf227](https://github.com/kkvesper/ts-loader/commit/53bf227))
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/kkvesper/ts-loader/compare/3.1.0...3.1.1) (2018-03-05)
 

--- a/lib/cordovaLoad.js
+++ b/lib/cordovaLoad.js
@@ -7,7 +7,7 @@ const throat = throater(Promise);
 
 export default function cordovaLoad(serverRoot, forceReload, manifest, onProgress) {
   const files = Object.keys(manifest.files).map(fileName => manifest.files[fileName])
-    .filter(file => file)
+    .filter(file => file && file.type !== 'css')
     .map(({ path }) => path);
 
   const cache = new CordovaFileCache({
@@ -38,8 +38,14 @@ export default function cordovaLoad(serverRoot, forceReload, manifest, onProgres
   })
   .then(() => {
     return Promise.all(manifest.domNodes.map(throat(1, (nodeInfo) => {
-      const cachePath = cache.get(nodeInfo.path);
-      nodeInfo.path = cachePath.replace(/^file:\/\//, '');
+      if (nodeInfo.type === 'css') {
+        if (!nodeInfo.path.match(/^http(s|):\/\//)) {
+          nodeInfo.path = `${serverRoot}${nodeInfo.path}`;
+        }
+      } else {
+        const cachePath = cache.get(nodeInfo.path);
+        nodeInfo.path = cachePath.replace(/^file:\/\//, '');
+      }
       return new DomNode(nodeInfo);
     })));
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "main": "dist/ts-loader.js",
   "repository": "https://github.com/kkvesper/ts-loader",


### PR DESCRIPTION
For compatability with LogRocket styles loading we should just load the absolute URL and not cache the file locally.